### PR TITLE
add onTranscript callback

### DIFF
--- a/src/useWhisper.ts
+++ b/src/useWhisper.ts
@@ -32,6 +32,7 @@ const defaultConfig: UseWhisperConfig = {
   timeSlice: 1_000,
   onDataAvailable: undefined,
   onTranscribe: undefined,
+  onTranscript: undefined,
 }
 
 /**
@@ -66,6 +67,7 @@ export const useWhisper: UseWhisperHook = (config) => {
     whisperConfig,
     onDataAvailable: onDataAvailableCallback,
     onTranscribe: onTranscribeCallback,
+    onTranscript: onTranscriptCallback,
   } = {
     ...defaultConfig,
     ...config,
@@ -436,6 +438,7 @@ export const useWhisper: UseWhisperHook = (config) => {
             const file = new File([blob], 'speech.mp3', { type: 'audio/mpeg' })
             const text = await onWhispered(file)
             console.log('onTranscribing', { text })
+            onTranscriptCallback(text)
             setTranscript({
               blob,
               text,


### PR DESCRIPTION
This callback is called when a transcript is received from whisper. Won't be called when `streaming` is `true`.

I find this easier to consume the resulting transcript if it must be sent to another method or api, rather than having to compare state over time. Let me know if there's an existing or better way to achieve this.

This is sent as proof of concept, I'll also edit the readme if you validate this contribution.. Thanks!