### PR TITLE
feat: Add resetTranscript function

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ const App = () => {
     pauseRecording,
     startRecording,
     stopRecording,
+    resetTranscript,
   } = useWhisper({
     apiKey: process.env.OPENAI_API_TOKEN, // YOUR_OPEN_AI_TOKEN
   })
@@ -57,6 +58,7 @@ const App = () => {
       <button onClick={() => startRecording()}>Start</button>
       <button onClick={() => pauseRecording()}>Pause</button>
       <button onClick={() => stopRecording()}>Stop</button>
+      <button onClick={() => resetTranscript()}>Reset</button>
     </div>
   )
 }
@@ -260,15 +262,17 @@ _most of these dependecies are lazy loaded, so it is only imported when it is ne
 
 - ###### Return Object
 
-| Name           | Type                      | Description                                                               |
-| -------------- | ------------------------- | ------------------------------------------------------------------------- |
-| recording      | boolean                   | speech recording state                                                    |
-| speaking       | boolean                   | detect when user is speaking                                              |
-| transcribing   | boolean                   | while removing silence from speech and send request to OpenAI Whisper API |
-| transcript     | [Transcript](#transcript) | object return after Whisper transcription complete                        |
-| pauseRecording | Promise                   | pause speech recording                                                    |
-| startRecording | Promise                   | start speech recording                                                    |
-| stopRecording  | Promise                   | stop speech recording                                                     |
+| Name            | Type                      | Description                                                               |
+| --------------- | ------------------------- | ------------------------------------------------------------------------- |
+| recording       | boolean                   | speech recording state                                                    |
+| speaking        | boolean                   | detect when user is speaking                                              |
+| transcribing    | boolean                   | while removing silence from speech and send request to OpenAI Whisper API |
+| transcript      | [Transcript](#transcript) | object return after Whisper transcription complete                        |
+| pauseRecording  | Promise                   | pause speech recording                                                    |
+| startRecording  | Promise                   | start speech recording                                                    |
+| stopRecording   | Promise                   | stop speech recording                                                     |
+| stopRecording   | Promise                   | stop speech recording                                                     |
+| resetTranscript | () => void                | set transcript to the default value                                       |
 
 - ###### Transcript
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,7 @@ export type UseWhisperReturn = {
   pauseRecording: () => Promise<void>
   startRecording: () => Promise<void>
   stopRecording: () => Promise<void>
+  resetTranscript: () => void
 }
 
 export type UseWhisperHook = (config?: UseWhisperConfig) => UseWhisperReturn

--- a/src/useWhisper.ts
+++ b/src/useWhisper.ts
@@ -527,6 +527,14 @@ export const useWhisper: UseWhisperHook = (config) => {
     [apiKey, mode, whisperConfig]
   )
 
+  /**
+   * reset transcript to the default state
+   * - set defaultTranscript value to the transcript
+   */
+   const resetTranscript = () => {
+    setTranscript(defaultTranscript);
+  }
+
   return {
     recording,
     speaking,
@@ -535,5 +543,6 @@ export const useWhisper: UseWhisperHook = (config) => {
     pauseRecording,
     startRecording,
     stopRecording,
+    resetTranscript,
   }
 }


### PR DESCRIPTION
The `resetTranscript` sets the default state for the `transcript`.

In some cases, setting the default state for this one would be very useful.
Please let me know if there is a more effective method to accomplish this. Thank you!

Resolves https://github.com/chengsokdara/use-whisper/issues/30