### PR TITLE
Support private deployed whisper service

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ _most of these dependecies are lazy loaded, so it is only imported when it is ne
 | Name            | Type                                               | Default Value  | Description                                                                                                          |
 | --------------- | -------------------------------------------------- | -------------- | -------------------------------------------------------------------------------------------------------------------- |
 | apiKey          | string                                             | ''             | your OpenAI API token                                                                                                |
+| apiBase         | string                                             | 'https://api.openai.com/v1'             | your OpenAI API base  |
 | autoStart       | boolean                                            | false          | auto start speech recording on component mount                                                                       |
 | autoTranscribe  | boolean                                            | true           | should auto transcribe after stop recording                                                                          |
 | mode            | string                                             | transcriptions | control Whisper mode either transcriptions or translations, currently only support translation to English            |

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -6,4 +6,3 @@ export const ffmpegCoreUrl =
 export const silenceRemoveCommand =
   'silenceremove=start_periods=1:stop_periods=-1:start_threshold=-30dB:stop_threshold=-30dB:start_silence=2:stop_silence=2'
 
-export const whisperApiEndpoint = 'https://api.openai.com/v1/audio/'

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 export type UseWhisperConfig = {
   apiKey?: string
+  apiBase?: string
   autoStart?: boolean
   autoTranscribe?: boolean
   mode?: 'transcriptions' | 'translations'

--- a/src/useWhisper.ts
+++ b/src/useWhisper.ts
@@ -8,7 +8,6 @@ import {
   defaultStopTimeout,
   ffmpegCoreUrl,
   silenceRemoveCommand,
-  whisperApiEndpoint,
 } from './configs'
 import {
   UseWhisperConfig,
@@ -22,6 +21,7 @@ import {
  */
 const defaultConfig: UseWhisperConfig = {
   apiKey: '',
+  apiBase: 'https://api.openai.com/v1',
   autoStart: false,
   autoTranscribe: true,
   mode: 'transcriptions',
@@ -55,6 +55,7 @@ const defaultTranscript: UseWhisperTranscript = {
 export const useWhisper: UseWhisperHook = (config) => {
   const {
     apiKey,
+    apiBase,
     autoStart,
     autoTranscribe,
     mode,
@@ -519,12 +520,12 @@ export const useWhisper: UseWhisperHook = (config) => {
         headers['Authorization'] = `Bearer ${apiKey}`
       }
       const { default: axios } = await import('axios')
-      const response = await axios.post(whisperApiEndpoint + mode, body, {
+      const response = await axios.post(apiBase + '/audio/' + mode, body, {
         headers,
       })
       return response.data.text
     },
-    [apiKey, mode, whisperConfig]
+    [apiKey, apiBase, mode, whisperConfig]
   )
 
   return {


### PR DESCRIPTION
Recently, I'm working on [a repo](https://github.com/huajianmao/llm-as-openai) which provides openai compatible APIs for LLM and whisper model. And I want to use this awesome `use-whisper` project in my app with my own deployed whisper service.

The [`openai`](https://platform.openai.com/docs/api-reference/introduction) package supports setting `apiBase` with `openai.api_base = "http://localhost:8000/api/v1"` to use other openai services like Azure OpenAI services.

It might be better to support `apiBase` configuration to enhance this awesome project.

With this PR, we can use this repo with a private whisper service.
```jsx
import { useWhisper } from '@chengsokdara/use-whisper'

const App = () => {
  const {
    recording,
    speaking,
    transcribing,
    transcript,
    pauseRecording,
    startRecording,
    stopRecording,
  } = useWhisper({
    apiKey: 'none',
    apiBase: 'http://localhost:8000/api/v1'
  })

  return (
    <div>
      <p>Recording: {recording}</p>
      <p>Speaking: {speaking}</p>
      <p>Transcribing: {transcribing}</p>
      <p>Transcribed Text: {transcript.text}</p>
      <button onClick={() => startRecording()}>Start</button>
      <button onClick={() => pauseRecording()}>Pause</button>
      <button onClick={() => stopRecording()}>Stop</button>
    </div>
  )
}
```