### PR TITLE
verbose_json: Return full response from openAI

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,7 @@ export type UseWhisperTimeout = {
 export type UseWhisperTranscript = {
   blob?: Blob
   text?: string
+  response?: any // support for verbose_json
 }
 
 export type UseWhisperReturn = {


### PR DESCRIPTION
When response format is set to verbose_json (on whisper options) it keeps returning only the clean text and for example not the segments array when building a transcription timeline. 

Added the raw response that comes from OpenAI and updated UseWhisperTranscript type. 

`
export type UseWhisperTranscript = {
  blob?: Blob
  text?: string
  response?: any // support for verbose_json
}`