### PR TITLE
fix: use npm registry instead of retrieving project through ssh

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@ffmpeg/ffmpeg": "^0.11.6",
     "axios": "^1.3.4",
     "hark": "^1.2.3",
-    "lamejs": "github:zhuker/lamejs",
+    "lamejs": "^1.2.1",
     "recordrtc": "^5.6.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -988,9 +988,10 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
-"lamejs@github:zhuker/lamejs":
+lamejs@^1.2.1:
   version "1.2.1"
-  resolved "https://codeload.github.com/zhuker/lamejs/tar.gz/582bbba6a12f981b984d8fb9e1874499fed85675"
+  resolved "https://registry.yarnpkg.com/lamejs/-/lamejs-1.2.1.tgz#0f92d38729213f106d4a19ded20821da7e89c8e4"
+  integrity sha512-s7bxvjvYthw6oPLCm5pFxvA84wUROODB8jEO2+CE1adhKgrIvVOlmMgY8zyugxGrvRaDHNJanOiS21/emty6dQ==
   dependencies:
     use-strict "1.0.1"
 


### PR DESCRIPTION
Hi @chengsokdara, 👋 

Using SSH for getting package is a really bad practice for security and regression reason.
Code present on #master branch seems to be the code deployed on NPM.

> An another example of side effect to not use NPM: 
> When we install your (nice) package, it's mandatory into our Dockerfile image to add SSH a the Gihub Public git... 

Have a nice day.
Regards,